### PR TITLE
fix: Constrain cli_mate to version 0.6.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule MixVersion.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:cli_mate, "~> 0.3", runtime: false}
+      {:cli_mate, "~> 0.6.0", runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
-  "cli_mate": {:hex, :cli_mate, "0.3.0", "0ec2a19183e7c574172bb44b9d225ab46ef2fbb7203065c4cc8f24c0ea05e437", [:mix], [], "hexpm", "3e1248f37d93059d3a420b0a5aaaeaf13a807a8796f4c4d23088275cb53fad5e"},
+  "cli_mate": {:hex, :cli_mate, "0.6.0", "ee218a9bd1f315529f5384d67a05c1081479f724737d3e3ead29d6b0b3fcd4ed", [:mix], [], "hexpm", "34fb38dd14c0090b81e48ea3525730c5186884fbe0109a00bbd16647418508c6"},
   "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm", "3cb154b00225ac687f6cbd4acc4b7960027c757a5152b369923ead9ddbca7aec"},
   "doctor": {:hex, :doctor, "0.15.0", "8d1e74c65216ccefa852b831fb4f5c67e59faf2f3cd279e8e11e6446cb927755", [:mix], [{:decimal, "~> 1.8", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "b9808459c1848a7130c88c962c322bd9b2909b713756d77aadd446c1f1a92ab3"},


### PR DESCRIPTION
`cli_mate` 0.7 was recently released which has some deprecations. This library hasn't been updated to support those deprecations yet. When installing this tool via `mix archive.install`, it pulls down the latest matching version of `cli_mate`, which would be `0.7.1` at the time of submitting this. Since this tool isn't compatible with that version, would it be okay to just use an older version of `cli_mate` in the mean time until this project can be updated?